### PR TITLE
[codex] Skip missing MEXT subcommittee pages

### DIFF
--- a/lib/feeds/mext_space_wg.rb
+++ b/lib/feeds/mext_space_wg.rb
@@ -15,7 +15,9 @@ class MextSpaceWg < Feed
     items << extract_item(doc)
 
     doc.css('#contentsMain > p a').each do |sub_wg_anchor|
-      sub_wg_doc = Nokogiri::HTML.parse(URI.join(self.class.link, sub_wg_anchor['href']).open)
+      sub_wg_doc = fetch_sub_wg_doc(sub_wg_anchor)
+      next unless sub_wg_doc
+
       items << extract_item(sub_wg_doc)
     end
 
@@ -23,6 +25,14 @@ class MextSpaceWg < Feed
   end
 
   private
+
+  def fetch_sub_wg_doc(anchor_element)
+    link = URI.join(self.class.link, anchor_element['href'])
+    Nokogiri::HTML.parse(link.open)
+  rescue OpenURI::HTTPError => e
+    logger.warn("Skipping #{anchor_element.content.strip} (#{link}): #{e.message}")
+    nil
+  end
 
   def extract_item(doc)
     anchor_element = doc.at_xpath("//a[text()='配付資料']")


### PR DESCRIPTION
## 変更の意図

GitHub Pages のフィード生成が、MEXT の小委員会ページ 1 件の `404 Not Found` で全体失敗していたため、到達不能な小委員会 index だけをスキップするようにしました。

MEXT のメインページには将来宇宙輸送システム調査検討小委員会へのリンクが追加されていますが、リンク先の `https://www.mext.go.jp/b_menu/shingi/gijyutu/gijyutu2/104/index.htm` は現時点で 404 を返します。既存実装では小委員会リンクをすべて無条件に取得していたため、外部サイト側の一時的または不整合なリンク状態で Pages build が止まっていました。

この変更では、既存の配付資料抽出ロジックは維持しつつ、小委員会 index の取得だけを helper に分離し、HTTP エラー時は warning を出してその小委員会をスキップします。

## 確認

- `RBENV_VERSION=4.0.1 bundle exec rake`
- `RBENV_VERSION=4.0.1 bundle exec rubocop`

ローカルには `.ruby-version` の Ruby `4.0.2` が未インストールだったため、確認はインストール済みの Ruby `4.0.1` で実施しました。
